### PR TITLE
Fixed heap corruption in setDatabasePath

### DIFF
--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -789,7 +789,6 @@ void Countly::setDatabasePath(const std::string& path) {
 		}
 	} else {
 		log(Countly::LogLevel::ERROR, "Failed to open sqlite database");
-		sqlite3_free(error_message);
 		database_path.clear();
 	}
 	sqlite3_close(database);


### PR DESCRIPTION
I recently faced a heap corruption crash in my application when calling `countly_c_init` with a stateFilePath to a recently created file in the users temporary folder (which could be locked by an AV software or something like that). In my log file I got "Failed to open sqlite database" as last message before the crash. So I looked in the countly_skd_c code and found this message if `sqlite3_open` fails.

I think the reason for my crash was the line I removed. `error_message` is never used (or set) with `sqlite3_open`. So this line frees a random not allocated memory (from the uninitialized variable `error_message`), which causes the heap corruption.